### PR TITLE
New prequel-compiler changes

### DIFF
--- a/cmd/preq/preq.go
+++ b/cmd/preq/preq.go
@@ -226,33 +226,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	/*
-		if cli.Generate {
-			var (
-				//currRulesVer *semver.Version
-				//template []byte
-				err      error
-			)
-
-			if currRulesVer, _, err = rules.GetCurrentRulesVersion(defaultConfigDir); err != nil {
-				log.Error().Err(err).Msg("Failed to get current rules version")
-			}
-
-				if template, err = ruleMatchers.DataSourceTemplate(currRulesVer); err != nil {
-					log.Error().Err(err).Msg("Failed to generate data source template")
-					ux.RulesError(err)
-					os.Exit(1)
-				}
-
-				if _, err = os.Stdout.Write(template); err != nil {
-					log.Error().Err(err).Msg("Failed to write data source template")
-					ux.RulesError(err)
-					os.Exit(1)
-				}
-			os.Exit(0)
-		}
-	*/
-
 	if len(sources) == 0 {
 		ux.PrintUsage()
 		os.Exit(1)

--- a/cmd/preq/preq.go
+++ b/cmd/preq/preq.go
@@ -42,7 +42,6 @@ var (
 var cli struct {
 	Disabled      bool   `short:"d" help:"Do not run community CREs"`
 	Stop          string `short:"e" help:"Stop time"`
-	Generate      bool   `short:"g" help:"Generate data sources template"`
 	JsonLogs      bool   `short:"j" help:"Print logs in JSON format to stderr" default:"false"`
 	Skip          int    `short:"k" help:"Skip the first N lines for timestamp detection" default:"20"`
 	Level         string `short:"l" help:"Print logs at this level to stderr"`

--- a/examples/04-set-1x1-example.yaml
+++ b/examples/04-set-1x1-example.yaml
@@ -3,7 +3,6 @@ rules:
       id: set-1x1
     rule:
       set:
-        window: 10s
         event:
           source: kafka
         match:

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 require (
 	github.com/cqroot/prompt v0.9.4
 	github.com/fatih/color v1.18.0
-	github.com/prequel-dev/prequel-compiler v0.0.3
+	github.com/prequel-dev/prequel-compiler v0.0.4
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 require (
 	github.com/cqroot/prompt v0.9.4
 	github.com/fatih/color v1.18.0
-	github.com/prequel-dev/prequel-compiler v0.0.2
+	github.com/prequel-dev/prequel-compiler v0.0.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/prequel-dev/prequel-compiler v0.0.3 h1:iz9A1toIq4Jc8Zu2Zidhhhn5HC/ONUZO4hm42A6H5Ww=
-github.com/prequel-dev/prequel-compiler v0.0.3/go.mod h1:zoSXiDZwwxyLUnsuNRDJg14fxK3bop0ed4rvgUx071U=
+github.com/prequel-dev/prequel-compiler v0.0.4 h1:SzW3Bk50kgbpe+Hu79TWf4PEdEcGtEmwqcSli79ybyI=
+github.com/prequel-dev/prequel-compiler v0.0.4/go.mod h1:QVq33Sxlexq/ikDKqNsMQMKK+ga9aDgQemQZFNUXxGI=
 github.com/prequel-dev/prequel-logmatch v0.0.11 h1:RGp5ajqRMmKhl7dNlpxSm+KJdolGDBd73SymZbCU0oQ=
 github.com/prequel-dev/prequel-logmatch v0.0.11/go.mod h1:Dpfd/79s8vMCmIdmNQ5kC8WAvw/XjOd2z6wEIe3Lkck=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prequel-dev/prequel-compiler v0.0.3 h1:iz9A1toIq4Jc8Zu2Zidhhhn5HC/ONUZO4hm42A6H5Ww=
 github.com/prequel-dev/prequel-compiler v0.0.3/go.mod h1:zoSXiDZwwxyLUnsuNRDJg14fxK3bop0ed4rvgUx071U=
-github.com/prequel-dev/prequel-core v0.0.37 h1:EmZFseykkHvFwOX6cklALxSP0gQfNNAmhuDBwD+0Mk0=
-github.com/prequel-dev/prequel-core v0.0.37/go.mod h1:f31ABZHxMr2L0OM5jRx5tNEvst7zhEHI0KCBZAKavNQ=
 github.com/prequel-dev/prequel-logmatch v0.0.11 h1:RGp5ajqRMmKhl7dNlpxSm+KJdolGDBd73SymZbCU0oQ=
 github.com/prequel-dev/prequel-logmatch v0.0.11/go.mod h1:Dpfd/79s8vMCmIdmNQ5kC8WAvw/XjOd2z6wEIe3Lkck=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/prequel-dev/prequel-compiler v0.0.2 h1:n7LaoxtxrPDB+ib5YsGK+VY5OVXZRWXXKeAOMm3oLpU=
-github.com/prequel-dev/prequel-compiler v0.0.2/go.mod h1:QVq33Sxlexq/ikDKqNsMQMKK+ga9aDgQemQZFNUXxGI=
+github.com/prequel-dev/prequel-compiler v0.0.3 h1:iz9A1toIq4Jc8Zu2Zidhhhn5HC/ONUZO4hm42A6H5Ww=
+github.com/prequel-dev/prequel-compiler v0.0.3/go.mod h1:zoSXiDZwwxyLUnsuNRDJg14fxK3bop0ed4rvgUx071U=
+github.com/prequel-dev/prequel-core v0.0.37 h1:EmZFseykkHvFwOX6cklALxSP0gQfNNAmhuDBwD+0Mk0=
+github.com/prequel-dev/prequel-core v0.0.37/go.mod h1:f31ABZHxMr2L0OM5jRx5tNEvst7zhEHI0KCBZAKavNQ=
 github.com/prequel-dev/prequel-logmatch v0.0.11 h1:RGp5ajqRMmKhl7dNlpxSm+KJdolGDBd73SymZbCU0oQ=
 github.com/prequel-dev/prequel-logmatch v0.0.11/go.mod h1:Dpfd/79s8vMCmIdmNQ5kC8WAvw/XjOd2z6wEIe3Lkck=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/pkg/engine/engine.go
+++ b/internal/pkg/engine/engine.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prequel-dev/prequel-compiler/pkg/compiler"
 	"github.com/prequel-dev/prequel-compiler/pkg/matchz"
 	"github.com/prequel-dev/prequel-compiler/pkg/parser"
+	"github.com/prequel-dev/prequel-compiler/pkg/pqerr"
 	"github.com/prequel-dev/prequel-compiler/pkg/schema"
 	"github.com/prequel-dev/prequel-logmatch/pkg/entry"
 	lm "github.com/prequel-dev/prequel-logmatch/pkg/match"
@@ -88,6 +89,7 @@ func compileRulePath(cf compiler.RuntimeI, path string) (compiler.ObjsT, *parser
 	)
 
 	log.Info().Str("path", path).Msg("Parsing rules")
+
 	if rules, err = utils.ParseRulesPath(path); err != nil {
 		log.Error().Err(err).Msg("Failed to parse rules")
 		return nil, nil, err
@@ -104,10 +106,7 @@ func compileRulePath(cf compiler.RuntimeI, path string) (compiler.ObjsT, *parser
 
 	nodeObjs, err = compileRuleTree(cf, tree)
 	if err != nil {
-		log.Error().Err(err).
-			Str("path", path).
-			Msg("Failed to compile rule tree")
-		return nil, nil, err
+		return nil, nil, pqerr.WithFile(err, path)
 	}
 
 	return nodeObjs, rules, nil
@@ -472,7 +471,6 @@ func (r *RuntimeT) CompileRulesPath(rulesPaths []string, report *ux.ReportT) (*R
 	runtime := r.getRuntimeCb(report)
 
 	if nodeObjs, configs, err = r.compileRulesPaths(runtime, rulesPaths); err != nil {
-		log.Error().Err(err).Msg("Failed to load rules")
 		return nil, err
 	}
 
@@ -500,7 +498,6 @@ func (r *RuntimeT) LoadRulesPaths(rep *ux.ReportT, rulesPaths []string) (*RuleMa
 	)
 
 	if ruleMatchers, err = r.CompileRulesPath(rulesPaths, rep); err != nil {
-		log.Error().Err(err).Msg("Failed to compile rules")
 		return nil, err
 	}
 

--- a/internal/pkg/engine/engine.go
+++ b/internal/pkg/engine/engine.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prequel-dev/preq/internal/pkg/resolve"
 	"github.com/prequel-dev/preq/internal/pkg/utils"
 	"github.com/prequel-dev/preq/internal/pkg/ux"
-	"github.com/prequel-dev/prequel-compiler/pkg/ast"
 	"github.com/prequel-dev/prequel-compiler/pkg/compiler"
 	"github.com/prequel-dev/prequel-compiler/pkg/matchz"
 	"github.com/prequel-dev/prequel-compiler/pkg/parser"
@@ -105,7 +104,9 @@ func compileRulePath(cf compiler.RuntimeI, path string) (compiler.ObjsT, *parser
 
 	nodeObjs, err = compileRuleTree(cf, tree)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to compile rule tree")
+		log.Error().Err(err).
+			Str("path", path).
+			Msg("Failed to compile rule tree")
 		return nil, nil, err
 	}
 
@@ -293,8 +294,8 @@ func loadNodeObjs(objs compiler.ObjsT) (*RuleMatchersT, error) {
 			return nil, ErrExpectedMatcherCb
 		}
 
-		switch obj.Type {
-		case ast.NodeTypeLogSeq:
+		switch obj.AbstractType {
+		case schema.NodeTypeLogSeq:
 
 			switch o := obj.Object.(type) {
 			case *lm.InverseSeq, *lm.MatchSeq:
@@ -307,7 +308,7 @@ func loadNodeObjs(objs compiler.ObjsT) (*RuleMatchersT, error) {
 				return nil, ErrUnknownObjectType
 			}
 
-		case ast.NodeTypeLogSet:
+		case schema.NodeTypeLogSet:
 			switch o := obj.Object.(type) {
 			case *lm.MatchSingle, *lm.MatchSet, *lm.MatchFunc, *lm.InverseSet:
 				m.match[obj.RuleId] = o
@@ -322,7 +323,7 @@ func loadNodeObjs(objs compiler.ObjsT) (*RuleMatchersT, error) {
 		default:
 			log.Error().
 				Str("rule_id", obj.RuleId).
-				Str("type", obj.Type.String()).
+				Str("abstract_type", obj.AbstractType.String()).
 				Any("obj", obj).
 				Msg("Unknown object type")
 			return nil, ErrUnknownObjectType
@@ -373,6 +374,14 @@ func (r *runtimeT) NewCbAssert(params compiler.AssertParamsT) compiler.CbAssertT
 	}
 }
 
+func (r *runtimeT) LoadAssertObject(ctx context.Context, obj *compiler.ObjT) error {
+	return nil
+}
+
+func (r *runtimeT) LoadMachineObject(ctx context.Context, obj *compiler.ObjT, userCb any) error {
+	return nil
+}
+
 // Permit wasm compile rules from a byte slice
 func (r *RuntimeT) CompileRules(ruleData []byte, report *ux.ReportT) (*RuleMatchersT, error) {
 	var (
@@ -406,11 +415,12 @@ func (r *RuntimeT) getRuntimeCb(report *ux.ReportT) *runtimeT {
 	runtime := NewRuntime(func(params compiler.MatchParamsT, m matchz.HitsT) error {
 
 		var (
-			cre parser.ParseCreT
+			cre      parser.ParseCreT
+			ruleHash = params.Address.GetRuleHash()
 		)
 
-		if cre, err = r.getCre(params.RuleHash); err != nil {
-			log.Error().Str("rule_hash", params.RuleHash).Msg("Failed to get CRE for rule")
+		if cre, err = r.getCre(ruleHash); err != nil {
+			log.Error().Str("rule_hash", ruleHash).Msg("Failed to get CRE for rule")
 			return err
 		}
 

--- a/internal/pkg/ux/ux.go
+++ b/internal/pkg/ux/ux.go
@@ -26,6 +26,7 @@ const (
 	ErrorCategoryData   = "Data"
 	ErrorCategoryConfig = "Config"
 	ErrorCategoryAuth   = "Auth"
+	ErrorHelpData       = "https://docs.prequel.dev/timestamps"
 )
 
 const (
@@ -212,7 +213,15 @@ func AuthError(err error) error {
 
 func CategoryError(category string, err error) error {
 	fmt.Fprintf(os.Stderr, "%s error: %v\n", category, err)
+	ErrorHelp(category)
 	return err
+}
+
+func ErrorHelp(category string) {
+	switch category {
+	case ErrorCategoryData:
+		fmt.Fprintf(os.Stderr, "See %s for help resolving this error\n", ErrorHelpData)
+	}
 }
 
 func Error(err error) error {


### PR DESCRIPTION
adds new error handling

```
$ cat /tmp/rabbit | ./bin/preq-linux-amd64 
Rules error: err="invalid window", line=388, col=17, cre_id=CRE-2025-0030, rule_id=5BYEbapiuQSU2AzoTERt1V, rule_hash=E2kz7cjUmaNWVGN6rJw1BGaNouHi2fQ14FJFMKy87ZMw, file=/home/tony/.preq/prequel-public-cre-rules.0.3.8.cecbee12.yaml.gz
```