### PR TITLE
Support Linear Action

### DIFF
--- a/internal/pkg/runbook/linear.go
+++ b/internal/pkg/runbook/linear.go
@@ -1,0 +1,143 @@
+package runbook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"text/template"
+)
+
+type linearConfig struct {
+	SecretEnv           string `yaml:"secret_env"`
+	Secret              string `yaml:"secret"`
+	TitleTemplate       string `yaml:"title_template"`
+	DescriptionTemplate string `yaml:"description_template"`
+	TeamID              string `yaml:"team_id"`
+}
+
+type linearAction struct {
+	token      string
+	teamID     string
+	titleTmpl  *template.Template
+	descTmpl   *template.Template
+}
+
+func newLinearAction(cfg linearConfig) (Action, error) {
+	if cfg.TeamID == "" {
+		return nil, errors.New("linear.team_id is required")
+	}
+	if cfg.TitleTemplate == "" {
+		return nil, errors.New("linear.title_template is required")
+	}
+	if cfg.DescriptionTemplate == "" {
+		return nil, errors.New("linear.description_template is required")
+	}
+
+	st, err := template.New("linear-title").Funcs(funcMap()).Parse(cfg.TitleTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("linear title template error: %w", err)
+	}
+	dt, err := template.New("linear-desc").Funcs(funcMap()).Parse(cfg.DescriptionTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("linear description template error: %w", err)
+	}
+
+	if cfg.Secret == "" && cfg.SecretEnv != "" {
+		cfg.Secret = os.Getenv(cfg.SecretEnv)
+	}
+	if cfg.Secret == "" {
+		return nil, errors.New("linear secret missing; set either 'secret' or 'secret_env'")
+	}
+
+	return &linearAction{
+		token:     cfg.Secret,
+		teamID:    cfg.TeamID,
+		titleTmpl: st,
+		descTmpl:  dt,
+	}, nil
+}
+
+func (a *linearAction) Execute(ctx context.Context, cre map[string]any) error {
+	var title, desc string
+  if err := executeTemplate(&title, a.titleTmpl, cre); err != nil {
+		return fmt.Errorf("linear: title: %w", err)
+	}
+  if err := executeTemplate(&desc, a.descTmpl, cre); err != nil {
+		return fmt.Errorf("linear: description: %w", err)
+	}
+
+	query := `mutation IssueCreate($input: IssueCreateInput!) {
+		issueCreate(input: $input) {
+			success
+			issue { id url title }
+		}
+	}`
+
+	vars := map[string]any{
+		"input": map[string]any{
+			"title":       title,
+			"description": desc,
+			"teamId":      a.teamID,
+		},
+	}
+
+	payload := map[string]any{
+		"query":     query,
+		"variables": vars,
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("linear: encode: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.linear.app/graphql", bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("linear: request: %w", err)
+	}
+	req.Header.Set("Authorization", a.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("linear: post: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 300 {
+		return fmt.Errorf("linear: HTTP %d", res.StatusCode)
+	}
+
+	var out struct {
+		Data struct {
+			IssueCreate struct {
+				Success bool `json:"success"`
+				Issue   struct {
+					ID  string `json:"id"`
+					URL string `json:"url"`
+				} `json:"issue"`
+			} `json:"issueCreate"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		return fmt.Errorf("linear: decode: %w", err)
+	}
+	if len(out.Errors) > 0 {
+		return errors.New(out.Errors[0].Message)
+	}
+	if !out.Data.IssueCreate.Success {
+		return errors.New("linear: issue creation failed")
+	}
+
+	log := out.Data.IssueCreate.Issue.URL
+	fmt.Fprintf(os.Stderr, "linear: created issue → %s\n", log)
+	return nil
+}

--- a/internal/pkg/runbook/runbook.go
+++ b/internal/pkg/runbook/runbook.go
@@ -41,12 +41,22 @@ actions:
         *preq detection*: [{{ field .cre "Id" }}] {{ field .cre "Title" }}
       description_template: |
         {{ (index .hits 0).Timestamp }}: {{ (index .hits 0).Entry }}
+  - type: linear
+    regex: "CRE-2025-0026"
+    linear:
+      team_id: 9cfb482a-81e3-4154-b5b9-2c805e70a02d
+      secret_env: LINEAR_TOKEN
+      title_template: |
+        [{{ field .cre "Id" }}] {{ field .cre "Title" }}
+      description_template: |
+        {{ (index .hits 0).Timestamp }}: {{ (index .hits 0).Entry }}
 */
 
 const (
-	ActionTypeSlack = "slack"
-	ActionTypeJira  = "jira"
-	ActionTypeExec  = "exec"
+	ActionTypeSlack  = "slack"
+	ActionTypeJira   = "jira"
+	ActionTypeLinear = "linear"
+	ActionTypeExec   = "exec"
 )
 
 type Action interface {
@@ -63,6 +73,7 @@ type actionConfig struct {
 
 	Slack *slackConfig `yaml:"slack,omitempty"`
 	Jira  *jiraConfig  `yaml:"jira,omitempty"`
+	Linear *linearConfig `yaml:"linear,omitempty"`
 	Exec  *execConfig  `yaml:"exec,omitempty"`
 }
 
@@ -141,6 +152,11 @@ func buildActions(cfgPath string) ([]Action, error) {
 				return nil, fmt.Errorf("missing exec section for action #%d", i)
 			}
 			a, err = newExecAction(*c.Exec)
+		case ActionTypeLinear:
+			if c.Linear == nil {
+				return nil, fmt.Errorf("missing linear section for action #%d", i)
+			}
+			a, err = newLinearAction(*c.Linear)
 		default:
 			err = fmt.Errorf("unknown action type %q (index %d)", c.Type, i)
 		}


### PR DESCRIPTION
Mirrors the `jira` action to add support for [Linear](https://linear.app) issue tracker.

The action config block looks like:
```yaml
- type: linear
    regex: "CRE-2025-0026"
    linear:
      team_id: "9cfb482a-81e3-4154-b5b9-2c805e70a02d"
      secret_env: LINEAR_TOKEN
      title_template: |
        [{{ field .cre "Id" }}] {{ field .cre "Title" }}
      description_template: |
        {{ stripdash (field .cre "Description") }}
        ### Impact
        {{ stripdash (field .cre "Impact") }}
        ### Cause
        {{ stripdash (field .cre "Cause") }}
        ## Mitigation
        {{ field .cre "Mitigation" }}
        {{- $refs := field .cre "References" -}}
        {{- if $refs }}
        ### References
        {{ range $refs }}
        - {{ . }}
        {{ end }}
        {{- end }}
        +++ ## Events
        {{- range .hits }}
          ```
          {{ .Entry }}
          ```
        {{- end }}
        +++
```

Also some CRE fields lead with a dash character which causes them to render as list items when they're interrupted as Markdown. So I added a `stripdash` function to the template helpers.