### PR TITLE
Add CLI parity tests and coverage output

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,31 +28,11 @@ jobs:
       - name: Run tests
         run: |
           go test ./... -covermode=count -coverpkg=./... -coverprofile=coverage.out
-          go tool cover -func=coverage.out -o coverage.out
+          go tool cover -func=coverage.out
+          COV=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | tr -d '%')
+          printf '{"totals": {"percent_covered_display": %.2f}}' "$COV" > coverage.json
 
-      - name: Generate coverage badge
-        uses: tj-actions/coverage-badge-go@v2
-        with:
-          filename: coverage.out
-
-      - name: Verify changed files
-        id: verify
-        uses: tj-actions/verify-changed-files@v16
-        with:
-          files: README.md
-
-      - name: Commit badge
-        if: steps.verify.outputs.files_changed == 'true'
-        run: |
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-          git add README.md
-          git commit -m "chore: update coverage badge"
-
-      - name: Push badge
-        if: steps.verify.outputs.files_changed == 'true'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref || github.ref_name }}
+      - name: Update coverage badge
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: we-cli/coverage-badge-action@v1.0.1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,58 @@
+name: coverage
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.24.2
+
+      - name: Run tests
+        run: |
+          go test ./... -covermode=count -coverpkg=./... -coverprofile=coverage.out
+          go tool cover -func=coverage.out -o coverage.out
+
+      - name: Generate coverage badge
+        uses: tj-actions/coverage-badge-go@v2
+        with:
+          filename: coverage.out
+
+      - name: Verify changed files
+        id: verify
+        uses: tj-actions/verify-changed-files@v16
+        with:
+          files: README.md
+
+      - name: Commit badge
+        if: steps.verify.outputs.files_changed == 'true'
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add README.md
+          git commit -m "chore: update coverage badge"
+
+      - name: Push badge
+        if: steps.verify.outputs.files_changed == 'true'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref || github.ref_name }}
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)
+[![Coverage](https://img.shields.io/badge/Coverage-0%25-red.svg)](https://github.com/prequel-dev/preq/actions/workflows/coverage.yml)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)
-![Coverage](https://img.shields.io/badge/Coverage-19.6%25-red)
+[![Coverage](https://prequel-dev.github.io/preq/badges/coverage.svg)](https://github.com/prequel-dev/preq/actions/workflows/coverage.yml)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)
-[![Coverage](https://img.shields.io/badge/Coverage-0%25-red.svg)](https://github.com/prequel-dev/preq/actions/workflows/coverage.yml)
+![Coverage](https://img.shields.io/badge/Coverage-19.6%25-red)
 
 ---
 

--- a/cmd/plugin/krew/krew.go
+++ b/cmd/plugin/krew/krew.go
@@ -123,7 +123,9 @@ func RootCmd(ctx context.Context, o *krewOptions) *cobra.Command {
 	// preq options
 	cmd.Flags().StringVarP(&cli.Options.Action, "action", "a", "", ux.HelpAction)
 	cmd.Flags().BoolVarP(&cli.Options.Disabled, "disabled", "d", false, ux.HelpDisabled)
-	cmd.Flags().BoolVarP(&cli.Options.Cron, "cronjob", "j", false, ux.HelpCron)
+	cmd.Flags().BoolVarP(&cli.Options.Cron, "cron", "j", false, ux.HelpCron)
+	cmd.Flags().BoolVarP(&cli.Options.Generate, "generate", "g", false, ux.HelpGenerate)
+	cmd.Flags().StringVarP(&cli.Options.Source, "source", "s", "", ux.HelpSource)
 	cmd.Flags().StringVarP(&cli.Options.Level, "level", "l", "", ux.HelpLevel)
 	cmd.Flags().StringVarP(&cli.Options.Name, "name", "o", "", ux.HelpName)
 	cmd.Flags().BoolVarP(&cli.Options.Quiet, "quiet", "q", false, ux.HelpQuiet)

--- a/test/cli_parity_test.go
+++ b/test/cli_parity_test.go
@@ -1,15 +1,16 @@
 package test
 
 import (
-	"context"
-	"reflect"
-	"strings"
-	"testing"
+        "context"
+        "reflect"
+        "strings"
+        "testing"
 
-	krewpkg "github.com/prequel-dev/preq/cmd/plugin/krew"
-	"github.com/prequel-dev/preq/internal/pkg/cli"
-	"github.com/spf13/pflag"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+        krewpkg "github.com/prequel-dev/preq/cmd/plugin/krew"
+        "github.com/prequel-dev/preq/internal/pkg/cli"
+        "github.com/google/go-cmp/cmp"
+        "github.com/spf13/pflag"
+        "k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func flagNameFromField(name string) string {
@@ -47,12 +48,12 @@ func krewFlagSet() map[string]struct{} {
 }
 
 func TestKrewAndCLIMatch(t *testing.T) {
-	cliFlags := cliFlagSet()
-	krewFlags := krewFlagSet()
+        cliFlags := cliFlagSet()
+        krewFlags := krewFlagSet()
 
-	if !reflect.DeepEqual(cliFlags, krewFlags) {
-		t.Fatalf("flags mismatch: cli=%v krew=%v", cliFlags, krewFlags)
-	}
+        if diff := cmp.Diff(cliFlags, krewFlags); diff != "" {
+                t.Fatalf("flags mismatch (-cli +krew):\n%s", diff)
+        }
 }
 
 func TestCoverageOutput(t *testing.T) {

--- a/test/cli_parity_test.go
+++ b/test/cli_parity_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	krewpkg "github.com/prequel-dev/preq/cmd/plugin/krew"
+	"github.com/prequel-dev/preq/internal/pkg/cli"
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func flagNameFromField(name string) string {
+	var out []rune
+	for i, r := range name {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				out = append(out, '-')
+			}
+			out = append(out, r+'a'-'A')
+		} else {
+			out = append(out, r)
+		}
+	}
+	return strings.ToLower(string(out))
+}
+
+func cliFlagSet() map[string]struct{} {
+	flags := map[string]struct{}{}
+	t := reflect.TypeOf(cli.Options)
+	for i := 0; i < t.NumField(); i++ {
+		name := flagNameFromField(t.Field(i).Name)
+		flags[name] = struct{}{}
+	}
+	return flags
+}
+
+func krewFlagSet() map[string]struct{} {
+	cmd := krewpkg.RootCmd(context.Background(), krewpkg.NewRunOptions(genericclioptions.IOStreams{}))
+	flags := map[string]struct{}{}
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		flags[f.Name] = struct{}{}
+	})
+	return flags
+}
+
+func TestKrewAndCLIMatch(t *testing.T) {
+	cliFlags := cliFlagSet()
+	krewFlags := krewFlagSet()
+
+	if !reflect.DeepEqual(cliFlags, krewFlags) {
+		t.Fatalf("flags mismatch: cli=%v krew=%v", cliFlags, krewFlags)
+	}
+}
+
+func TestCoverageOutput(t *testing.T) {
+	t.Logf("coverage: %.2f%%", testing.Coverage()*100)
+}


### PR DESCRIPTION
## Summary
- add CLI parity tests checking krew plugin flags
- add a coverage output test
- display test coverage in README

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.1)*
- `GOTOOLCHAIN=local go test -coverprofile=coverage.out ./...` *(fails: go.mod requires go >= 1.24.1)*
- `go tool cover -func=coverage.out` *(fails: couldn't download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68422b47f76c8330aa84ab4317f46dd6