### PR TITLE
Add unit tests for utility functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # preq
-![Coverage](https://img.shields.io/badge/Coverage-27.4%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-29.7%25-red)
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # preq
-![Coverage](https://img.shields.io/badge/Coverage-19.6%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-27.4%25-red)
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,74 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prequel-dev/preq/internal/pkg/config"
+)
+
+func TestMarshal(t *testing.T) {
+	out := config.Marshal()
+	if !strings.Contains(out, "timestamps:") {
+		t.Fatalf("expected timestamps in output")
+	}
+
+	out = config.Marshal(config.WithWindow(2 * time.Second))
+	if !strings.Contains(out, "window: 2s") {
+		t.Fatalf("expected window option in output")
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := config.LoadConfig(dir, "cfg.yaml", config.WithWindow(3*time.Second))
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if cfg.Window != 3*time.Second {
+		t.Fatalf("expected window 3s got %v", cfg.Window)
+	}
+	if len(cfg.TimestampRegexes) == 0 {
+		t.Fatalf("expected default timestamp regexes")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "cfg.yaml")); err != nil {
+		t.Fatalf("expected config file written: %v", err)
+	}
+}
+
+func TestLoadConfigFromBytes(t *testing.T) {
+	data := "timestamps: []\nwindow: 1s\n"
+	cfg, err := config.LoadConfigFromBytes(data)
+	if err != nil {
+		t.Fatalf("LoadConfigFromBytes: %v", err)
+	}
+	if cfg.Window != time.Second {
+		t.Fatalf("expected 1s window, got %v", cfg.Window)
+	}
+}
+
+func TestWriteDefaultConfigAndResolveOpts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	if err := config.WriteDefaultConfig(path, config.WithWindow(2*time.Second)); err != nil {
+		t.Fatalf("WriteDefaultConfig: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !strings.Contains(string(data), "window: 2s") {
+		t.Fatalf("window option missing")
+	}
+
+	cfg, err := config.LoadConfig(dir, "cfg.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.ResolveOpts()) == 0 {
+		t.Fatalf("expected resolve options")
+	}
+}

--- a/internal/pkg/runbook/runbook_test.go
+++ b/internal/pkg/runbook/runbook_test.go
@@ -1,0 +1,194 @@
+package runbook
+
+import (
+	"bytes"
+	"context"
+	"github.com/prequel-dev/preq/internal/pkg/ux"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"text/template"
+)
+
+type stubAction struct{ called bool }
+
+func (s *stubAction) Execute(ctx context.Context, m map[string]any) error {
+	s.called = true
+	return nil
+}
+
+func TestFilteredAction(t *testing.T) {
+	a := &stubAction{}
+	f := &filteredAction{pattern: regexp.MustCompile("CRE-1"), inner: a}
+
+	// no match
+	if err := f.Execute(context.Background(), map[string]any{"cre": map[string]any{"id": "CRE-2"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.called {
+		t.Fatalf("action should not run")
+	}
+
+	// match
+	if err := f.Execute(context.Background(), map[string]any{"cre": map[string]any{"id": "CRE-1"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !a.called {
+		t.Fatalf("action should run")
+	}
+}
+
+func TestFuncMapAndExecuteTemplate(t *testing.T) {
+	data := map[string]any{"cre": map[string]any{"ID": "CRE-9"}, "desc": "- message"}
+	funcs := funcMap()
+	tmpl, err := template.New("t").Funcs(funcs).Parse("{{field .cre \"ID\"}} {{stripdash .desc}}")
+	if err != nil {
+		t.Fatalf("template parse: %v", err)
+	}
+	var out string
+	if err := executeTemplate(&out, tmpl, data); err != nil {
+		t.Fatalf("executeTemplate: %v", err)
+	}
+	if out != "CRE-9 message" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestExtractCreId(t *testing.T) {
+	ev := map[string]any{"cre": map[string]any{"id": "A"}}
+	if id := extractCreId(ev); id != "A" {
+		t.Fatalf("map: expected A got %s", id)
+	}
+	type cre struct{ ID string }
+	ev["cre"] = &cre{ID: "B"}
+	if id := extractCreId(ev); id != "B" {
+		t.Fatalf("struct: expected B got %s", id)
+	}
+	delete(ev, "cre")
+	ev["id"] = "C"
+	if id := extractCreId(ev); id != "C" {
+		t.Fatalf("top-level: expected C got %s", id)
+	}
+}
+
+func TestNewExecAction(t *testing.T) {
+	_, err := newExecAction(execConfig{})
+	if err == nil {
+		t.Fatalf("expected error for missing path")
+	}
+	script := filepath.Join(t.TempDir(), "script.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ncat >/dev/null"), 0755)
+	a, err := newExecAction(execConfig{Path: script})
+	if err != nil {
+		t.Fatalf("newExecAction: %v", err)
+	}
+	if err := a.Execute(context.Background(), map[string]any{"id": "x"}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestNewSlackAction(t *testing.T) {
+	_, err := newSlackAction(slackConfig{})
+	if err == nil {
+		t.Fatalf("expected error for missing fields")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !bytes.Contains(body, []byte("CRE-5")) {
+			t.Errorf("missing id")
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	a, err := newSlackAction(slackConfig{WebhookURL: srv.URL, MessageTemplate: "{{field .cre \"ID\"}}"})
+	if err != nil {
+		t.Fatalf("newSlackAction: %v", err)
+	}
+	err = a.Execute(context.Background(), map[string]any{"cre": map[string]any{"ID": "CRE-5"}})
+	if err != nil {
+		t.Fatalf("execute slack: %v", err)
+	}
+}
+
+func TestBuildActions(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "run.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\nexit 0"), 0755)
+	cfg := "actions:\n- type: exec\n  exec:\n    path: " + script + "\n"
+	path := filepath.Join(t.TempDir(), "cfg.yaml")
+	os.WriteFile(path, []byte(cfg), 0644)
+	acts, err := buildActions(path)
+	if err != nil {
+		t.Fatalf("buildActions: %v", err)
+	}
+	if len(acts) != 1 {
+		t.Fatalf("expected 1 action got %d", len(acts))
+	}
+}
+
+func TestNewJiraActionAndAdfParagraph(t *testing.T) {
+	_, err := newJiraAction(jiraConfig{})
+	if err == nil {
+		t.Fatalf("expected error for missing fields")
+	}
+	os.Setenv("JIRA_TOKEN", "tok")
+	defer os.Unsetenv("JIRA_TOKEN")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !bytes.Contains(body, []byte("CRE-7")) {
+			t.Errorf("missing id")
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	cfg := jiraConfig{
+		WebhookURL:          srv.URL,
+		SecretEnv:           "JIRA_TOKEN",
+		SummaryTemplate:     "{{field .cre \"ID\"}}",
+		DescriptionTemplate: "d",
+		ProjectKey:          "PR",
+	}
+	a, err := newJiraAction(cfg)
+	if err != nil {
+		t.Fatalf("newJiraAction: %v", err)
+	}
+	para := adfParagraph("x")
+	if para["type"] != "doc" {
+		t.Fatalf("unexpected adf")
+	}
+	if err := a.Execute(context.Background(), map[string]any{"cre": map[string]any{"ID": "CRE-7"}}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestNewLinearAction(t *testing.T) {
+	_, err := newLinearAction(linearConfig{})
+	if err == nil {
+		t.Fatalf("expected error for missing fields")
+	}
+	os.Setenv("LIN_TOKEN", "tok")
+	defer os.Unsetenv("LIN_TOKEN")
+	cfg := linearConfig{TeamID: "T", SecretEnv: "LIN_TOKEN", TitleTemplate: "{{.}}", DescriptionTemplate: "d"}
+	a, err := newLinearAction(cfg)
+	if err != nil {
+		t.Fatalf("newLinearAction: %v", err)
+	}
+	if a == nil {
+		t.Fatalf("expected action")
+	}
+}
+
+func TestRunbook(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "run.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\nexit 0"), 0755)
+	cfg := "actions:\n- type: exec\n  exec:\n    path: " + script + "\n"
+	path := filepath.Join(t.TempDir(), "cfg.yaml")
+	os.WriteFile(path, []byte(cfg), 0644)
+	report := ux.ReportDocT{{"cre": map[string]any{"ID": "CRE"}}}
+	if err := Runbook(context.Background(), path, report); err != nil {
+		t.Fatalf("Runbook: %v", err)
+	}
+}

--- a/internal/pkg/timez/timez_test.go
+++ b/internal/pkg/timez/timez_test.go
@@ -1,0 +1,52 @@
+package timez_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prequel-dev/preq/internal/pkg/timez"
+)
+
+func TestGetTimestampFormat(t *testing.T) {
+	cb, err := timez.GetTimestampFormat(timez.FmtRfc3339)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ts, err := cb([]byte("2025-01-02T03:04:05Z"))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	want := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC).UnixNano()
+	if ts != want {
+		t.Fatalf("expected %d got %d", want, ts)
+	}
+}
+
+func TestEpochParserAndAny(t *testing.T) {
+	cb, _ := timez.GetTimestampFormat(timez.FmtEpochMillis)
+	ts, err := cb([]byte("42"))
+	if err != nil || ts != 42*int64(time.Millisecond) {
+		t.Fatalf("epoch millis failed")
+	}
+
+	cb, _ = timez.GetTimestampFormat(timez.FmtEpochAny)
+	ts, err = cb([]byte("1000"))
+	if err != nil || ts != 1000*int64(time.Second) {
+		t.Fatalf("epoch any failed")
+	}
+}
+
+func TestTryTimestampFormat(t *testing.T) {
+	line := "2025-06-06T12:00:00Z first line\nsecond" // newline ensures only first line used
+	factory, ts, err := timez.TryTimestampFormat(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)`, timez.FmtRfc3339, []byte(line), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if factory == nil {
+		t.Fatal("expected factory")
+	}
+	want := time.Date(2025, 6, 6, 12, 0, 0, 0, time.UTC).UnixNano()
+	if ts != want {
+		t.Fatalf("timestamp mismatch")
+	}
+}

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -1,0 +1,167 @@
+package utils_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prequel-dev/preq/internal/pkg/utils"
+)
+
+func TestSha256Sum(t *testing.T) {
+	got := utils.Sha256Sum([]byte("hello world"))
+	want := "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+	if got != want {
+		t.Fatalf("expected %s got %s", want, got)
+	}
+}
+
+func TestUrlBase(t *testing.T) {
+	base, err := utils.UrlBase("https://example.com/path/file.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if base != "file.txt" {
+		t.Fatalf("expected file.txt got %s", base)
+	}
+	if _, err := utils.UrlBase(":bad://url"); err == nil {
+		t.Fatalf("expected error for bad url")
+	}
+}
+
+func TestCopyFileAndOpenRulesFile(t *testing.T) {
+	srcFile, err := os.CreateTemp(t.TempDir(), "src-*.txt")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	srcFile.WriteString("content")
+	srcFile.Close()
+
+	dstPath := srcFile.Name() + "-dst"
+	if err := utils.CopyFile(srcFile.Name(), dstPath); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	dstBytes, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if string(dstBytes) != "content" {
+		t.Fatalf("copy mismatch")
+	}
+
+	r, cleanup, err := utils.OpenRulesFile(dstPath)
+	if err != nil {
+		t.Fatalf("open failed: %v", err)
+	}
+	data, _ := io.ReadAll(r)
+	cleanup()
+	if string(data) != "content" {
+		t.Fatalf("expected content from open")
+	}
+
+	// gzipped file
+	gzPath := dstPath + ".gz"
+	f, _ := os.Create(gzPath)
+	gz := gzip.NewWriter(f)
+	gz.Write([]byte("gzipped"))
+	gz.Close()
+	f.Close()
+
+	r, cleanup, err = utils.OpenRulesFile(gzPath)
+	if err != nil {
+		t.Fatalf("open gzip failed: %v", err)
+	}
+	data, _ = io.ReadAll(r)
+	cleanup()
+	if string(data) != "gzipped" {
+		t.Fatalf("expected gzipped content")
+	}
+}
+
+func TestGunzipBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/data.gz"
+	f, _ := os.Create(path)
+	gz := gzip.NewWriter(f)
+	gz.Write([]byte("hello"))
+	gz.Close()
+	f.Close()
+
+	out, err := utils.GunzipBytes(path)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if string(out) != "hello" {
+		t.Fatalf("expected hello got %s", string(out))
+	}
+}
+
+func TestExtractSectionBytes(t *testing.T) {
+	yamlData := "section: other\n" +
+		"---\n" +
+		"section: rules\nfoo: bar\n"
+	b, err := utils.ExtractSectionBytes(bytes.NewReader([]byte(yamlData)), "rules")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if !bytes.Contains(b, []byte("foo: bar")) {
+		t.Fatalf("unexpected section bytes: %s", string(b))
+	}
+}
+
+func TestExtractSectionBytesNotFound(t *testing.T) {
+	yamlData := "section: other\n"
+	_, err := utils.ExtractSectionBytes(bytes.NewReader([]byte(yamlData)), "rules")
+	if err == nil {
+		t.Fatalf("expected error for missing section")
+	}
+}
+
+func TestGetOSInfoAndStopTime(t *testing.T) {
+	info := utils.GetOSInfo()
+	if !strings.Contains(info, runtime.GOOS) {
+		t.Fatalf("unexpected os info: %s", info)
+	}
+	if utils.GetStopTime() <= 0 {
+		t.Fatalf("expected positive stop time")
+	}
+}
+
+func TestParseRules(t *testing.T) {
+	rule := "rules:\n  - cre:\n      id: r1\n    rule:\n      set:\n        window: 1s\n        event:\n          source: t\n        match:\n          - test\n"
+	r, err := utils.ParseRules(bytes.NewBufferString(rule), utils.WithGenIds())
+	if err != nil {
+		t.Fatalf("ParseRules: %v", err)
+	}
+	if len(r.Rules) != 1 {
+		t.Fatalf("expected 1 rule got %d", len(r.Rules))
+	}
+}
+
+func TestParseRulesPathMultiDoc(t *testing.T) {
+	data := "section: other\n---\nsection: rules\n" +
+		"rules:\n  - metadata:\n      id: m1\n    cre:\n      id: r2\n    rule:\n      set:\n        window: 1s\n        event:\n          source: t\n        match:\n          - test\n"
+	tmp := filepath.Join(t.TempDir(), "rules.yaml")
+	os.WriteFile(tmp, []byte(data), 0644)
+	r, err := utils.ParseRulesPath(tmp, utils.WithMultiDoc())
+	if err != nil {
+		t.Fatalf("ParseRulesPath: %v", err)
+	}
+	if len(r.Rules) != 1 {
+		t.Fatalf("expected 1 rule got %d", len(r.Rules))
+	}
+}
+
+func TestGunzipBytesErrorAndCopyFileError(t *testing.T) {
+	if _, err := utils.GunzipBytes("bad.gz"); err == nil {
+		t.Fatalf("expected error")
+	}
+	if err := utils.CopyFile("missing", "dst"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/pkg/verz/verz_test.go
+++ b/internal/pkg/verz/verz_test.go
@@ -1,0 +1,12 @@
+package verz
+
+import "testing"
+
+func TestSemver(t *testing.T) {
+	Major = "1"
+	Minor = "2"
+	Build = "3"
+	if Semver() != "1.2.3" {
+		t.Fatalf("unexpected semver: %s", Semver())
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for misc utilities
- add tests for timestamp helpers
- add tests for config loader and runbook helpers

## Testing
- `go test ./... -coverpkg=./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68426a705bfc8330bb624aa22e454df6