### PR TITLE
Embedded Runbook Expressions

### DIFF
--- a/internal/pkg/runbook/exec.go
+++ b/internal/pkg/runbook/exec.go
@@ -3,16 +3,18 @@ package runbook
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"text/template"
 )
 
 type execConfig struct {
-	Path string   `yaml:"path"`
-	Args []string `yaml:"args"`
+	Path    string   `yaml:"path"`
+	Expr    string   `yaml:"expr"`
+	Runtime string   `yaml:"runtime"` // optional, default to "sh -s"
+	Args    []string `yaml:"args"`
 }
 
 type execAction struct {
@@ -20,13 +22,17 @@ type execAction struct {
 }
 
 func newExecAction(cfg execConfig) (Action, error) {
-	if cfg.Path == "" {
-		return nil, errors.New("exec.path is required")
+	if cfg.Path == "" && cfg.Expr == "" {
+		return nil, errors.New("either exec.path or exec.expr is required")
+	}
+	if cfg.Path != "" && cfg.Expr != "" {
+		return nil, errors.New("exec.path and exec.expr are mutually exclusive")
 	}
 	return &execAction{cfg: cfg}, nil
 }
 
 func (e *execAction) Execute(ctx context.Context, cre map[string]any) error {
+	// Template substitution for args
 	args := make([]string, len(e.cfg.Args))
 	for i, a := range e.cfg.Args {
 		tmpl, err := template.New("arg").Funcs(funcMap()).Parse(a)
@@ -38,14 +44,48 @@ func (e *execAction) Execute(ctx context.Context, cre map[string]any) error {
 		}
 	}
 
-	raw, err := json.Marshal(cre)
-	if err != nil {
-		return err
+	var cmd *exec.Cmd
+
+	switch {
+	// External command with args
+	case e.cfg.Path != "":
+		cmd = exec.CommandContext(ctx, e.cfg.Path, args...)
+
+	// expr + runtime piped via stdin
+	case e.cfg.Expr != "":
+  	// Expand template variables
+  	expr, err := renderTemplate(e.cfg.Expr, cre)
+ 		if err != nil {
+			return err
+		}
+
+		runtime := e.cfg.Runtime
+		if runtime == "" {
+			runtime = "sh -s"
+		}
+
+		parts := splitRuntime(runtime)
+		cmd = exec.CommandContext(ctx, parts[0], append(parts[1:], args...)...)
+    cmd.Stdin = strings.NewReader(expr)
 	}
 
-	cmd := exec.CommandContext(ctx, e.cfg.Path, args...)
-	cmd.Stdin = bytes.NewReader(raw)
+	// Common output wiring
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
 	return cmd.Run()
+}
+
+func renderTemplate(input string, data map[string]any) (string, error) {
+	tmpl, err := template.New("inline").Funcs(funcMap()).Parse(input)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	return buf.String(), err
+}
+
+func splitRuntime(runtime string) []string {
+	return strings.Fields(runtime) // basic split
 }

--- a/internal/pkg/runbook/runbook.go
+++ b/internal/pkg/runbook/runbook.go
@@ -29,6 +29,9 @@ actions:
     regex: "CRE-2025-0025"
     exec:
       path: ./action.sh
+      expr: |
+        echo "Critical incident: {{ field .cre "Id" }}"
+      runtime: bash -
       args:
         - '{{ field .cre "Id" }}'
         - '{{ len .hits }}'


### PR DESCRIPTION
This extends the `exec` action with support for embedding expressions in the config file while maintaining the current behaviour.
```shell
- type: exec
    exec:
      expr: |
        if [ "{{ field .cre "Severity" }}" = 0 ]; then
          echo "🔥 Critical incident: {{ field .cre "Id" }}"
          echo "{{ stripdash (field .cre "Description") }}"
          touch /tmp/alert-{{ field .cre "Id" }}

          {{ range .hits }}
            echo "{{ . }}" >> /tmp/alert-{{ field $.cre "Id" }}
          {{ end }}

          echo "Logged {{ len .hits }} to /tmp/alert-{{ field .cre "Id" }}"
        else
          echo "Low priority incident. Ignoring."
        fi
```
Expressions are passed via stdio to a `runtime` which defaults to `sh -s` if not defined. This means support for a lot of scripting environments & CLI tools out of the box for free.

Likewise with container environments like Docker, k8s etc. It's just passing the command in `runtime`.
- Docker: `runtime: docker run -i --rm alpine sh -s`
- Podman: `runtime: podman exec -i my-container sh -s`
- k8s: `runtime: kubectl exec -i my-pod -c my-container -- sh -s`

## Examples
### SSH
```shell
runtime: ssh remotehost bash
expr: |
  if [ "{{ field .cre "Severity" }}" = 0 ]; then
    echo "🔥 Critical incident: {{ field .cre "Id" }}"
    echo "{{ stripdash (field .cre "Description") }}"
    touch /tmp/alert-{{ field .cre "Id" }}

    {{ range .hits }}
      echo "{{ . }}" >> /tmp/alert-{{ field $.cre "Id" }}
    {{ end }}

    echo "Logged {{ len .hits }} to /tmp/alert-{{ field .cre "Id" }}"
  else
    echo "Low priority incident. Ignoring."
  fi
```
### Python
```python
runtime: python3 -
expr: |
  import os

  severity = '{{ field .cre "Severity" }}'
  cre_id = '{{ field .cre "Id" }}'
  description = '''{{ stripdash (field .cre "Description") }}'''
  hit_count = '{{ len .hits }}'

  raw_hits = '''{{ .hits }}'''
  hits = raw_hits.strip().splitlines()

  if severity == "0":
      print(f"🔥 Critical incident: {cre_id}")
      print(description)

      path = f"/tmp/alert-{cre_id}"
      with open(path, "a") as f:
          for line in hits:
              f.write(line.strip() + "\n")

      print(f"Logged {hit_count} to {path}")
  else:
      print("Low priority incident. Ignoring.")
```
### Ruby
```ruby
runtime: ruby -
expr: |
	severity = '{{ field .cre "Severity" }}'
    cre_id = '{{ field .cre "Id" }}'
    description = <<~DESC
        {{ stripdash (field .cre "Description") }}
    DESC

    raw_hits = <<~HITS
        {{ .hits }}
    HITS

    hits = raw_hits.lines.map(&:chomp)

    if severity == "0"
        puts "🔥 Critical incident: #{cre_id}"
        puts description

        path = "/tmp/alert-#{cre_id}"
        File.open(path, "a") do |f|
    	    hits.each { |line| f.puts line }
        end

        puts "Logged {{ len .hits }} to #{path}"
    else
        puts "Low priority incident. Ignoring."
    end
```
### Node
```javascript
runtime: node -
expr: |
    const fs = require("fs");

    const severity = '{{ field .cre "Severity" }}';
    const creId = '{{ field .cre "Id" }}';
    const description = `{{ stripdash (field .cre "Description") }}`;
    const hits = {{ tojson .hits }};

    if (severity === "0") {
        console.log(`🔥 Critical incident: ${creId}`);
        console.log(description);

        const path = `/tmp/alert-${creId}.jsonl`;
        for (const hit of hits) {
            fs.appendFileSync(path, JSON.stringify(hit) + "\n");
        }

        console.log(`Logged ${hits.length} to ${path}`);
    } else {
        console.log("Low priority incident. Ignoring.");
    }
```