### PR TITLE
Add unit tests for CLI and Auth packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # preq
-![Coverage](https://img.shields.io/badge/Coverage-35.2%%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-39.8%25-red)
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # preq
-![Coverage](https://img.shields.io/badge/Coverage-29.7%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-35.2%%25-red)
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)

--- a/internal/pkg/auth/auth_test.go
+++ b/internal/pkg/auth/auth_test.go
@@ -1,0 +1,245 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+var (
+	testPrivateKey   *rsa.PrivateKey
+	testPublicKey    *rsa.PublicKey
+	testPublicKeyPEM []byte
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	testPrivateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic("failed to generate test key: " + err.Error())
+	}
+	testPublicKey = &testPrivateKey.PublicKey
+
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(testPublicKey)
+	if err != nil {
+		panic("failed to marshal test public key: " + err.Error())
+	}
+	testPublicKeyPEM = pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubKeyBytes,
+	})
+
+	os.Exit(m.Run())
+}
+
+func generateTestToken(claims *UserClaims, t *testing.T) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, err := token.SignedString(testPrivateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign test token: %v", err)
+	}
+	return tokenString
+}
+
+func TestEmailClaim(t *testing.T) {
+	t.Run("valid token", func(t *testing.T) {
+		payload := `{"email": "test@example.com"}`
+		encodedPayload := jwt.EncodeSegment([]byte(payload))
+		jwtString := "header." + encodedPayload + ".signature"
+
+		email, err := EmailClaim(jwtString)
+		if err != nil {
+			t.Fatalf("Expected no error, but got: %v", err)
+		}
+		if email != "test@example.com" {
+			t.Errorf("Expected email 'test@example.com', but got '%s'", email)
+		}
+	})
+
+	t.Run("invalid JWT segments", func(t *testing.T) {
+		_, err := EmailClaim("just.one.part")
+		if err == nil {
+			t.Fatal("Expected an error for an invalid number of segments, but got nil")
+		}
+	})
+
+	t.Run("malformed base64 payload", func(t *testing.T) {
+		_, err := EmailClaim("header.%%%%.signature")
+		if err == nil {
+			t.Fatal("Expected an error for a malformed payload, but got nil")
+		}
+	})
+
+	t.Run("payload missing email claim", func(t *testing.T) {
+		payload := `{"name": "test user"}`
+		encodedPayload := jwt.EncodeSegment([]byte(payload))
+		jwtString := "header." + encodedPayload + ".signature"
+
+		_, err := EmailClaim(jwtString)
+		if err != ErrInvalidTokenClaims {
+			t.Fatalf("Expected error '%v', but got '%v'", ErrInvalidTokenClaims, err)
+		}
+	})
+}
+
+func TestCheckLocalToken(t *testing.T) {
+	originalKey := publicJwtKeyPEM
+	publicJwtKeyPEM = testPublicKeyPEM
+	t.Cleanup(func() {
+		publicJwtKeyPEM = originalKey
+	})
+
+	tempDir := t.TempDir()
+	tokenPath := filepath.Join(tempDir, "test.token")
+
+	t.Run("valid token file", func(t *testing.T) {
+		claims := &UserClaims{StandardClaims: jwt.StandardClaims{ExpiresAt: time.Now().Add(time.Hour).Unix()}}
+		tokenString := generateTestToken(claims, t)
+		os.WriteFile(tokenPath, []byte(tokenString), 0644)
+
+		readToken, err := checkLocalToken(tokenPath)
+		if err != nil {
+			t.Fatalf("Expected no error for a valid token, but got: %v", err)
+		}
+		if readToken != tokenString {
+			t.Error("Returned token does not match original token")
+		}
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		claims := &UserClaims{StandardClaims: jwt.StandardClaims{ExpiresAt: time.Now().Add(-time.Hour).Unix()}}
+		tokenString := generateTestToken(claims, t)
+		os.WriteFile(tokenPath, []byte(tokenString), 0644)
+
+		_, err := checkLocalToken(tokenPath)
+		if err == nil || !strings.Contains(err.Error(), "token is expired") {
+			t.Fatalf("Expected an expiry error, but got: %v", err)
+		}
+	})
+
+	t.Run("malformed token file", func(t *testing.T) {
+		os.WriteFile(tokenPath, []byte("this is not a jwt"), 0644)
+		_, err := checkLocalToken(tokenPath)
+		if err == nil {
+			t.Fatal("Expected an error for a malformed token, but got nil")
+		}
+	})
+
+	t.Run("token signed with wrong key", func(t *testing.T) {
+		otherPrivateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, &UserClaims{})
+		tokenString, _ := token.SignedString(otherPrivateKey)
+		os.WriteFile(tokenPath, []byte(tokenString), 0644)
+
+		_, err := checkLocalToken(tokenPath)
+		if err == nil || !strings.Contains(err.Error(), "crypto/rsa: verification error") {
+			t.Fatalf("Expected a signature verification error, but got: %v", err)
+		}
+	})
+
+	t.Run("token file does not exist", func(t *testing.T) {
+		_, err := checkLocalToken("/path/that/does/not/exist.token")
+		if err == nil {
+			t.Fatal("Expected an error for a missing file, but got nil")
+		}
+	})
+}
+
+func TestLogin_LocalTokenExists(t *testing.T) {
+	originalKey := publicJwtKeyPEM
+	publicJwtKeyPEM = testPublicKeyPEM
+	t.Cleanup(func() {
+		publicJwtKeyPEM = originalKey
+	})
+
+	tempDir := t.TempDir()
+	tokenPath := filepath.Join(tempDir, "login.token")
+
+	expectedToken := generateTestToken(&UserClaims{
+		StandardClaims: jwt.StandardClaims{ExpiresAt: time.Now().Add(time.Hour).Unix()},
+	}, t)
+	os.WriteFile(tokenPath, []byte(expectedToken), 0644)
+
+	token, err := Login(context.Background(), "http://dummy-addr", tokenPath)
+
+	if err != nil {
+		t.Fatalf("Login failed when a valid local token exists: %v", err)
+	}
+	if token != expectedToken {
+		t.Errorf("Login returned an incorrect token. Got %s, want %s", token, expectedToken)
+	}
+}
+
+func TestAuthenticationFlow_EndToEnd(t *testing.T) {
+	originalKey := publicJwtKeyPEM
+	publicJwtKeyPEM = testPublicKeyPEM
+	t.Cleanup(func() {
+		publicJwtKeyPEM = originalKey
+	})
+
+	expectedClaims := &UserClaims{
+		StandardClaims: jwt.StandardClaims{ExpiresAt: time.Now().Add(time.Hour).Unix()},
+		Email:          "final-user@example.com",
+	}
+	finalTokenString := generateTestToken(expectedClaims, t)
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/rules":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(DeviceAuth{
+				DeviceCode: "test-device-code",
+				ExpiresIn:  60,
+				Interval:   0,
+			})
+		case "/v1/auth/token_poll_rules":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(TokenPollResponse{
+				AccessToken: "dummy-access-token",
+				IdToken:     "dummy-id-token",
+				OrgUuid:     "dummy-org-uuid",
+			})
+		case "/v1/auth/exchange_rules":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(Token{
+				Token: finalTokenString,
+				Type:  TokenTypePrequel,
+			})
+		default:
+			http.NotFound(w, r)
+			t.Errorf("Received unexpected request to path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(mockServer.Close)
+
+	deviceAuth, err := startAuth(context.Background(), mockServer.URL+"/v1/auth/rules")
+	if err != nil {
+		t.Fatalf("startAuth failed: %v", err)
+	}
+
+	tokenPollResponse, err := pollToken(context.Background(), mockServer.URL, deviceAuth)
+	if err != nil {
+		t.Fatalf("pollToken failed: %v", err)
+	}
+
+	finalToken, err := exchangeRulesToken(context.Background(), mockServer.URL, tokenPollResponse)
+	if err != nil {
+		t.Fatalf("exchangeRulesToken failed: %v", err)
+	}
+
+	if finalToken.Token != finalTokenString {
+		t.Errorf("Final token does not match expected. Got %s, want %s", finalToken.Token, finalTokenString)
+	}
+}

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -41,6 +41,15 @@ var (
 	ruleUpdateFile   = filepath.Join(defaultConfigDir, ".ruleupdate")
 )
 
+var (
+	getRulesFunc = func(ctx context.Context, conf *config.Config, configDir, cmdLineRules, token, ruleUpdateFile, baseAddr string, tlsPort, udpPort int) ([]utils.RulePathT, error) {
+		return rules.GetRules(ctx, conf, configDir, cmdLineRules, token, ruleUpdateFile, baseAddr, tlsPort, udpPort)
+	}
+	loginUserFunc = func(ctx context.Context, baseAddr, ruleToken string) (string, error) {
+		return auth.Login(ctx, baseAddr, ruleToken)
+	}
+)
+
 const (
 	tlsPort    = 443
 	udpPort    = 8081
@@ -105,7 +114,7 @@ func InitAndExecute(ctx context.Context) error {
 	}
 
 	// Log in for community rule updates
-	if token, err = auth.Login(ctx, baseAddr, ruleToken); err != nil {
+	if token, err = loginUserFunc(ctx, baseAddr, ruleToken); err != nil {
 		log.Error().Err(err).Msg("Failed to login")
 
 		// A notice will be printed if the email is not verified
@@ -128,7 +137,7 @@ func InitAndExecute(ctx context.Context) error {
 		c.Skip = timez.DefaultSkip
 	}
 
-	rulesPaths, err = rules.GetRules(ctx, c, defaultConfigDir, Options.Rules, token, ruleUpdateFile, baseAddr, tlsPort, udpPort)
+	rulesPaths, err = getRulesFunc(ctx, c, defaultConfigDir, Options.Rules, token, ruleUpdateFile, baseAddr, tlsPort, udpPort)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to get rules")
 		ux.RulesError(err)

--- a/internal/pkg/cli/cli_test.go
+++ b/internal/pkg/cli/cli_test.go
@@ -33,8 +33,6 @@ func TestDataSourceFileParsing(t *testing.T) {
 	tempDir := t.TempDir()
 
 	t.Run("valid data source file", func(t *testing.T) {
-		// FIX: Corrected the YAML indentation. The properties 'type', 'desc',
-		// and 'locations' must be indented to be part of the list item.
 		validContent := `
 version: 1.0
 sources:

--- a/internal/pkg/cli/cli_test.go
+++ b/internal/pkg/cli/cli_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prequel-dev/preq/internal/pkg/config"
+	"github.com/prequel-dev/preq/internal/pkg/utils"
+	"github.com/prequel-dev/prequel-compiler/pkg/datasrc"
+)
+
+func setupTest(t *testing.T) {
+	t.Cleanup(func() {
+		Options = struct {
+			Action        string `short:"a" help:"${actionHelp}"`
+			Disabled      bool   `short:"d" help:"${disabledHelp}"`
+			Generate      bool   `short:"g" help:"${generateHelp}"`
+			Cron          bool   `short:"j" help:"${cronHelp}"`
+			Level         string `short:"l" help:"${levelHelp}"`
+			Name          string `short:"o" help:"${nameHelp}"`
+			Quiet         bool   `short:"q" help:"${quietHelp}"`
+			Rules         string `short:"r" help:"${rulesHelp}"`
+			Source        string `short:"s" help:"${sourceHelp}"`
+			Version       bool   `short:"v" help:"${versionHelp}"`
+			AcceptUpdates bool   `short:"y" help:"${acceptUpdatesHelp}"`
+		}{}
+	})
+}
+
+func TestDataSourceFileParsing(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("valid data source file", func(t *testing.T) {
+		// FIX: Corrected the YAML indentation. The properties 'type', 'desc',
+		// and 'locations' must be indented to be part of the list item.
+		validContent := `
+version: 1.0
+sources:
+  - name: my-log-source
+    type: log
+    desc: "my-log"
+    locations:
+      - path: /some/path/app.log
+`
+		validFile := filepath.Join(tempDir, "valid_sources.yaml")
+		if err := os.WriteFile(validFile, []byte(validContent), 0644); err != nil {
+			t.Fatalf("Failed to write valid source file: %v", err)
+		}
+
+		parsedData, err := datasrc.ParseFile(validFile)
+		if err != nil {
+			t.Fatalf("datasrc.ParseFile failed on a valid file: %v", err)
+		}
+
+		err = datasrc.Validate(parsedData)
+		if err != nil {
+			t.Fatalf("datasrc.Validate failed on valid parsed data: %v", err)
+		}
+	})
+
+	t.Run("invalid yaml syntax", func(t *testing.T) {
+		invalidContent := "version: 1.0\n  sources: - name: broken"
+		invalidFile := filepath.Join(tempDir, "invalid_sources.yaml")
+		if err := os.WriteFile(invalidFile, []byte(invalidContent), 0644); err != nil {
+			t.Fatalf("Failed to write invalid source file: %v", err)
+		}
+
+		_, err := datasrc.ParseFile(invalidFile)
+		if err == nil {
+			t.Fatal("Expected an error for malformed YAML, but got nil")
+		}
+	})
+
+	t.Run("source file not found", func(t *testing.T) {
+		_, err := datasrc.ParseFile(filepath.Join(tempDir, "non_existent_file.yaml"))
+		if err == nil {
+			t.Fatal("Expected an error for a non-existent file, but got nil")
+		}
+	})
+}
+
+func TestInitAndExecute_OptionParsing(t *testing.T) {
+	setupTest(t)
+
+	originalGetRules := getRulesFunc
+	originalLoginUser := loginUserFunc
+	t.Cleanup(func() {
+		getRulesFunc = originalGetRules
+		loginUserFunc = originalLoginUser
+	})
+
+	tempDir := t.TempDir()
+
+	dummyRuleContent := `
+rules:
+  - cre:
+      id: cre-2025-0000
+    metadata:
+      id: mC5rnfG5qz4TyHNscXKuJL
+      hash: cBsS3QQY1fwPVFUfYkKtHQ
+    rule:
+      set:
+        window: 5s
+        event:
+          source: cre.log.kafka
+        match:
+          - commonExpression1
+          - "this is another match"
+`
+	dummyRuleFile := filepath.Join(tempDir, "dummy-rule.yaml")
+	if err := os.WriteFile(dummyRuleFile, []byte(dummyRuleContent), 0644); err != nil {
+		t.Fatalf("Failed to write dummy rule file: %v", err)
+	}
+
+	var capturedCLIRules string
+	getRulesFunc = func(ctx context.Context, conf *config.Config, configDir, cmdLineRules, token, updateFile, baseAddr string, tlsPort, udpPort int) ([]utils.RulePathT, error) {
+		capturedCLIRules = cmdLineRules
+		return []utils.RulePathT{
+			{Path: dummyRuleFile, Type: utils.RuleTypeUser},
+		}, nil
+	}
+
+	loginUserFunc = func(ctx context.Context, s1, s2 string) (string, error) {
+		return "dummy-token", nil
+	}
+
+	expectedRulePath := "/path/to/my/rule.yaml"
+	Options.Rules = expectedRulePath
+
+	dummySourceFile := filepath.Join(tempDir, "dummy-source.yaml")
+	os.WriteFile(dummySourceFile, []byte("version: 1"), 0644)
+	Options.Source = dummySourceFile
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+
+	os.Stdout = nil
+	os.Stderr = nil
+
+	t.Cleanup(func() {
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	err := InitAndExecute(context.Background())
+
+	if err != nil {
+		t.Errorf("Expected InitAndExecute to run without error, but got: %v", err)
+	}
+
+	if capturedCLIRules != expectedRulePath {
+		t.Errorf("Expected CLI option for rules to be '%s', but captured '%s'", expectedRulePath, capturedCLIRules)
+	}
+}


### PR DESCRIPTION
Added unit and integration tests for cli focusing to:
- Test `parseSources` with valid, invalid an empty data-source files.
- Mock `rules.GetRules` and `auth.Login` using monkey-patching in `InitAndExecute` to confirm option parsing.

Since there was no dependency injection I couldn't use interfaces for rules.GetRules and auth.Login, so I wrote some package-level function variables for both helping me directly mock them in the test file and isolate them from other (network, fs, etc) dependencies.

Also. while writing tests I saw that the current `datasrc.Validate() `and `datasrc.Parsefile()` are more permissive and do not currently return errors for cases like: missing source key (considers file just with version: 1.0) and invalid source type (doesn't check the type field) 

I'll add these checks to the datasrc package once these are confirmed.

Looking forward for feedback and review! Thanks! 

Partially closes: #48 
cc @tonymeehan 