### PR TITLE
Add Unit tests for Logs, Resolve, Rules and Sigs Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # preq
-![Coverage](https://img.shields.io/badge/Coverage-39.8%25-red)
+![Coverage](https://img.shields.io/badge/Coverage-45.2%25-orange)
 [![Unit Tests](https://github.com/prequel-dev/cre/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/cre/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/preq/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/preq/actions/workflows/build.yml)
 [![Unit Tests](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml/badge.svg)](https://github.com/prequel-dev/prequel-compiler/actions/workflows/build.yml)

--- a/internal/pkg/logs/logs_test.go
+++ b/internal/pkg/logs/logs_test.go
@@ -1,0 +1,73 @@
+package logs
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestShortenCaller(t *testing.T) {
+	testCases := []struct {
+		name     string
+		file     string
+		line     int
+		expected string
+	}{
+		{
+			name:     "long unix path",
+			file:     "/home/user/go/src/github.com/prequel-dev/preq/internal/pkg/cli/cli.go",
+			line:     42,
+			expected: "cli.go:42",
+		},
+		{
+			name:     "long windows path",
+			file:     `C:\Users\user\go\src\github.com\prequel-dev\preq\internal\pkg\cli\cli.go`,
+			line:     101,
+			expected: `C:\Users\user\go\src\github.com\prequel-dev\preq\internal\pkg\cli\cli.go:101`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := shortenCaller(0, tc.file, tc.line)
+			if result != tc.expected {
+				t.Errorf("Expected '%s', but got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestMkTimestampFormatter(t *testing.T) {
+	const testTimeFormat = time.RFC1123
+
+	var buf bytes.Buffer
+
+	writer := zerolog.ConsoleWriter{
+		Out:             &buf,
+		FormatTimestamp: mkTimestampFormatter(testTimeFormat, 37),
+		NoColor:         true,
+	}
+
+	logger := zerolog.New(writer).With().Timestamp().Logger()
+
+	logTime := time.Date(2023, 10, 28, 10, 30, 0, 0, time.UTC)
+	expectedTimeString := logTime.Local().Format(testTimeFormat)
+
+	zerolog.TimestampFunc = func() time.Time {
+		return logTime
+	}
+	t.Cleanup(func() {
+		zerolog.TimestampFunc = time.Now
+	})
+
+	logger.Info().Msg("hello world")
+
+	output := buf.String()
+
+	if !strings.Contains(output, expectedTimeString) {
+		t.Errorf("Expected log output to contain timestamp '%s', but it was not found in '%s'", expectedTimeString, output)
+	}
+}

--- a/internal/pkg/resolve/resolve_test.go
+++ b/internal/pkg/resolve/resolve_test.go
@@ -1,0 +1,159 @@
+package resolve
+
+import (
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prequel-dev/prequel-compiler/pkg/datasrc"
+)
+
+func createTestFile(t *testing.T, dir, name, content string, useGzip bool) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	var fileContent strings.Builder
+	fileContent.WriteString(content + "\n")
+	for fileContent.Len() < detectSampleSize+100 {
+		fileContent.WriteString("This is a filler line to make the file large enough.\n")
+	}
+
+	finalBytes := []byte(fileContent.String())
+
+	if useGzip {
+		gz := gzip.NewWriter(f)
+		if _, err := gz.Write(finalBytes); err != nil {
+			t.Fatalf("Failed to write gzipped content: %v", err)
+		}
+		gz.Close()
+	} else {
+		if _, err := f.Write(finalBytes); err != nil {
+			t.Fatalf("Failed to write plain content: %v", err)
+		}
+	}
+	f.Close()
+	return path
+}
+
+func TestNewLogSrc(t *testing.T) {
+	tempDir := t.TempDir()
+	logContent := "2023-10-28T10:30:00Z This is a test log line."
+
+	t.Run("with plain text file", func(t *testing.T) {
+		path := createTestFile(t, tempDir, "test.log", logContent, false)
+
+		src, err := newLogSrc(path)
+		if err != nil {
+			t.Fatalf("newLogSrc failed for plain file: %v", err)
+		}
+		defer src.Close()
+
+		info, _ := os.Stat(path)
+		if src.Size() != info.Size() {
+			t.Errorf("Expected size %d, got %d", info.Size(), src.Size())
+		}
+	})
+
+	t.Run("with gzipped file", func(t *testing.T) {
+		path := createTestFile(t, tempDir, "test.log.gz", logContent, true)
+
+		src, err := newLogSrc(path)
+		if err != nil {
+			t.Fatalf("newLogSrc failed for gzipped file: %v", err)
+		}
+		defer src.Close()
+
+		if src.Size() != -1 {
+			t.Errorf("Expected size -1 for gzip, got %d", src.Size())
+		}
+	})
+
+	t.Run("with window option", func(t *testing.T) {
+		path := createTestFile(t, tempDir, "window.log", logContent, false)
+		expectedWindow := int64(30)
+
+		src, err := newLogSrc(path, WithWindow(expectedWindow))
+		if err != nil {
+			t.Fatalf("newLogSrc failed: %v", err)
+		}
+		defer src.Close()
+
+		if src.Window() != expectedWindow {
+			t.Errorf("Expected window %d, got %d", expectedWindow, src.Window())
+		}
+	})
+
+	t.Run("with non-existent file", func(t *testing.T) {
+		_, err := newLogSrc(filepath.Join(tempDir, "not-real.log"))
+		if err == nil {
+			t.Fatal("Expected an error for a non-existent file, but got nil")
+		}
+	})
+}
+
+func TestResolveSource(t *testing.T) {
+	tempDir := t.TempDir()
+	logContent := "2023-10-28T10:40:00Z some log content"
+	logPath := createTestFile(t, tempDir, "app.log", logContent, false)
+
+	t.Run("with valid source", func(t *testing.T) {
+		dss := &datasrc.DataSources{
+			Sources: []datasrc.Source{
+				{
+					Name:      "my-app",
+					Type:      "log",
+					Locations: []datasrc.Location{{Path: logPath}},
+				},
+			},
+		}
+
+		results := Resolve(dss)
+		if len(results) != 1 {
+			t.Fatalf("Expected 1 resolved source, got %d", len(results))
+		}
+		if results[0].Name() != "my-app" {
+			t.Errorf("Expected resolved source name to be 'my-app', got '%s'", results[0].Name())
+		}
+	})
+}
+
+func TestPipeStdin(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("2023-10-28T11:00:00Z Piped log content\n")
+	for b.Len() < detectSampleSize+100 {
+		b.WriteString("Filler line for stdin test.\n")
+	}
+	logContent := b.String()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+
+	originalStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+	})
+
+	go func() {
+		defer w.Close()
+		w.Write([]byte(logContent))
+	}()
+
+	results, err := PipeStdin()
+	if err != nil {
+		t.Fatalf("PipeStdin returned an unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("Expected PipeStdin to return 1 LogData source, but got %d", len(results))
+	}
+}

--- a/internal/pkg/rules/rules_test.go
+++ b/internal/pkg/rules/rules_test.go
@@ -1,0 +1,170 @@
+package rules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/prequel-dev/preq/internal/pkg/verz"
+)
+
+func TestShouldUpdateExe(t *testing.T) {
+	originalMajor := verz.Major
+	originalMinor := verz.Minor
+	originalBuild := verz.Build
+
+	verz.Major = "1"
+	verz.Minor = "2"
+	verz.Build = "3"
+
+	t.Cleanup(func() {
+		verz.Major = originalMajor
+		verz.Minor = originalMinor
+		verz.Build = originalBuild
+	})
+
+	testCases := []struct {
+		name         string
+		response     *RuleUpdateResponse
+		shouldUpdate bool
+	}{
+		{
+			name:         "Newer version available",
+			response:     &RuleUpdateResponse{LatestExeVersion: "1.3.0"},
+			shouldUpdate: true,
+		},
+		{
+			name:         "Older version available",
+			response:     &RuleUpdateResponse{LatestExeVersion: "1.2.0"},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Same version available",
+			response:     &RuleUpdateResponse{LatestExeVersion: "1.2.3"},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Newer prerelease version",
+			response:     &RuleUpdateResponse{LatestExeVersion: "1.2.4-alpha.1"},
+			shouldUpdate: true,
+		},
+		{
+			name:         "Empty version in response",
+			response:     &RuleUpdateResponse{LatestExeVersion: ""},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Malformed version in response",
+			response:     &RuleUpdateResponse{LatestExeVersion: "not-a-version"},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Nil response object",
+			response:     nil,
+			shouldUpdate: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := shouldUpdateExe(tc.response)
+			if result != tc.shouldUpdate {
+				t.Errorf("Expected shouldUpdate to be %v, but got %v", tc.shouldUpdate, result)
+			}
+		})
+	}
+}
+
+func TestShouldUpdateRules(t *testing.T) {
+	currentVersion := semver.MustParse("2.5.0")
+
+	testCases := []struct {
+		name         string
+		response     *RuleUpdateResponse
+		shouldUpdate bool
+	}{
+		{
+			name:         "Newer version available",
+			response:     &RuleUpdateResponse{LatestRuleVersion: "2.6.0"},
+			shouldUpdate: true,
+		},
+		{
+			name:         "Older version available",
+			response:     &RuleUpdateResponse{LatestRuleVersion: "2.4.9"},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Same version available",
+			response:     &RuleUpdateResponse{LatestRuleVersion: "2.5.0"},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Empty version in response",
+			response:     &RuleUpdateResponse{LatestRuleVersion: ""},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Malformed version in response",
+			response:     &RuleUpdateResponse{LatestRuleVersion: "not-a-version"},
+			shouldUpdate: false,
+		},
+		{
+			name:         "Nil response object",
+			response:     nil,
+			shouldUpdate: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := shouldUpdateRules(currentVersion, tc.response)
+			if result != tc.shouldUpdate {
+				t.Errorf("Expected shouldUpdate to be %v, but got %v", tc.shouldUpdate, result)
+			}
+		})
+	}
+}
+
+func TestPostUrl(t *testing.T) {
+	expectedResponse := map[string]string{"status": "ok"}
+	expectedToken := "my-secret-token"
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected method 'POST', got '%s'", r.Method)
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("Expected 'Accept: application/json' header, got '%s'", r.Header.Get("Accept"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected 'Content-Type: application/json' header, got '%s'", r.Header.Get("Content-Type"))
+		}
+		authHeader := fmt.Sprintf("Bearer %s", expectedToken)
+		if r.Header.Get("Authorization") != authHeader {
+			t.Errorf("Expected 'Authorization' header '%s', got '%s'", authHeader, r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedResponse)
+	}))
+	t.Cleanup(mockServer.Close)
+
+	requestBody := []byte(`{"request_key":"request_value"}`)
+	responseData, err := postUrl(context.Background(), mockServer.URL, expectedToken, requestBody, 5*time.Second)
+	if err != nil {
+		t.Fatalf("postUrl returned an unexpected error: %v", err)
+	}
+
+	var actualResponse map[string]string
+	if err := json.Unmarshal(responseData, &actualResponse); err != nil {
+		t.Fatalf("Failed to unmarshal response data: %v", err)
+	}
+	if status, ok := actualResponse["status"]; !ok || status != "ok" {
+		t.Errorf("Response body does not match expected. Got %v", actualResponse)
+	}
+}

--- a/internal/pkg/sigs/sigs_test.go
+++ b/internal/pkg/sigs/sigs_test.go
@@ -1,0 +1,34 @@
+package sigs
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestHandleKill(t *testing.T) {
+	t.Run("context is cancelled on real signal", func(t *testing.T) {
+		ctx := handleKill(context.Background(), syscall.SIGUSR1)
+
+		process, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			t.Fatalf("Failed to find current process: %v", err)
+		}
+
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			process.Signal(syscall.SIGUSR1)
+		}()
+
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); err != context.Canceled {
+				t.Errorf("Expected context to be canceled, but got error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Test timed out: context was not cancelled after signal was sent")
+		}
+	})
+}


### PR DESCRIPTION
Added unit and integration tests for:

1. Logs:
    - Tested `mkTimestampFormatter` formatting and `shortenCaller` path trimming.
2. Resolve:
     - Added `newLogSrc` tests with plain text file, with gzipped file, with window opt and with empty file checks
    -  Added `resolveSource` test with a valid source 
    -  Added `PipeStdin` test.
    -  All with verified timestamp detection
3. Rules:
    - Added unit test for `shouldUpdateExe` and `shouldUpdateRules` with various semantic versions.
    - Added test for `postUrl` using httptest.
4. Sigs:
    - Added test for `HandleKill` cancel signals

Please let me know if there are some feedbacks! Thanks!
Partially closes #48 
cc @tonymeehan 