### PR TITLE
fix: auth should use increased timeout while Auth Download Requests

### DIFF
--- a/internal/pkg/rules/download.go
+++ b/internal/pkg/rules/download.go
@@ -107,13 +107,13 @@ func rulesDownloadAuthRequest(ctx context.Context, retries int, baseUrl, rulesDo
 	)
 }
 
-func downloadPackage(ctx context.Context, apiUrl, packageUrl, token string, totalSize int64, pw progress.Writer, slowCheckTimeout, downloadTimeout time.Duration) ([]byte, error) {
+func downloadPackage(ctx context.Context, apiUrl, packageUrl, token string, totalSize int64, pw progress.Writer, downloadTimeout time.Duration) ([]byte, error) {
 	var (
 		authHdrs *RulesDownloadAuth
 		err      error
 	)
 
-	if authHdrs, err = rulesDownloadAuthRequest(ctx, numAttempts, apiUrl, packageUrl, token, slowCheckTimeout); err != nil {
+	if authHdrs, err = rulesDownloadAuthRequest(ctx, numAttempts, apiUrl, packageUrl, token, downloadTimeout); err != nil {
 		log.Error().Err(err).Msg("Fail RulesDownloadAuthRequest")
 		return nil, err
 	}

--- a/internal/pkg/rules/rules.go
+++ b/internal/pkg/rules/rules.go
@@ -380,7 +380,7 @@ func requestExeUpdate(ctx context.Context, fullResp *RuleUpdateResponse, apiUrl,
 		}
 	}
 
-	eb, err = downloadPackage(ctx, apiUrl, dataUrl, token, dataSize, pw, slowCheckTimeout, downloadTimeout)
+	eb, err = downloadPackage(ctx, apiUrl, dataUrl, token, dataSize, pw, downloadTimeout)
 	if err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ func requestExeUpdate(ctx context.Context, fullResp *RuleUpdateResponse, apiUrl,
 		Str("path", newExePath).
 		Msg("Temp updated exe path")
 
-	hb, err = downloadPackage(ctx, apiUrl, hashUrl, token, hashSize, pw, slowCheckTimeout, downloadTimeout)
+	hb, err = downloadPackage(ctx, apiUrl, hashUrl, token, hashSize, pw, downloadTimeout)
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func requestExeUpdate(ctx context.Context, fullResp *RuleUpdateResponse, apiUrl,
 		Str("path", newExeHashPath).
 		Msg("Temp updated exe hash path")
 
-	sb, err = downloadPackage(ctx, apiUrl, sigUrl, token, sigSize, pw, slowCheckTimeout, downloadTimeout)
+	sb, err = downloadPackage(ctx, apiUrl, sigUrl, token, sigSize, pw, downloadTimeout)
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func requestRuleUpdate(ctx context.Context, fullResp *RuleUpdateResponse, apiUrl
 		rb, hb, sb      []byte
 	)
 
-	rb, err = downloadPackage(ctx, apiUrl, fullResp.RuleUrls.DataUrl, token, fullResp.RuleUrls.DataSize, pw, slowCheckTimeout, downloadTimeout)
+	rb, err = downloadPackage(ctx, apiUrl, fullResp.RuleUrls.DataUrl, token, fullResp.RuleUrls.DataSize, pw, downloadTimeout)
 	if err != nil {
 		return "", err
 	}
@@ -525,7 +525,7 @@ func requestRuleUpdate(ctx context.Context, fullResp *RuleUpdateResponse, apiUrl
 		Str("path", newRulePath).
 		Msg("Temp updated rule path")
 
-	hb, err = downloadPackage(ctx, apiUrl, fullResp.RuleUrls.HashUrl, token, fullResp.RuleUrls.HashSize, pw, slowCheckTimeout, downloadTimeout)
+	hb, err = downloadPackage(ctx, apiUrl, fullResp.RuleUrls.HashUrl, token, fullResp.RuleUrls.HashSize, pw, downloadTimeout)
 	if err != nil {
 		return "", err
 	}
@@ -539,7 +539,7 @@ func requestRuleUpdate(ctx context.Context, fullResp *RuleUpdateResponse, apiUrl
 		Str("path", newRuleHashPath).
 		Msg("Temp updated rule hash path")
 
-	sb, err = downloadPackage(ctx, apiUrl, fullResp.RuleUrls.SigUrl, token, fullResp.RuleUrls.SigSize, pw, slowCheckTimeout, downloadTimeout)
+	sb, err = downloadPackage(ctx, apiUrl, fullResp.RuleUrls.SigUrl, token, fullResp.RuleUrls.SigSize, pw, downloadTimeout)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Updated the downloadPackage which was using `slowCheckTimeout` instead of `downloadTimeout` which was too short (300ms) and causing timeouts.

cc: @tonymeehan 